### PR TITLE
Fix packaging discovery and add finding coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ logs/
 !logs/.gitkeep
 data/
 !data/.gitkeep
+build/
+dist/
 
 # VS Code / IDE
 .vscode/

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+"""Default advisory configuration shipped with the Shai-Hulud audit toolkit."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Fetch and scan for npm packages compromised in the Shai-Hulud attack."
 readme = "README.md"
 authors = [{name = "Shai-Hulud Audit Toolkit Contributors"}]
-license = {text = "MIT License"}
+license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = []
 keywords = ["security", "npm", "supply-chain", "audit"]
@@ -25,6 +25,12 @@ Homepage = "https://github.com/example/shai-hulud-audit-toolkit"
 shai-hulud-audit = "scripts.audit:run"
 shai-hulud-fetch = "scripts.fetch:run"
 shai-hulud-scan = "scripts.scan:run"
+
+[tool.setuptools]
+packages = ["scripts", "config"]
+
+[tool.setuptools.package-data]
+config = ["*.json"]
 
 [tool.ruff]
 line-length = 140

--- a/tests/test_scan_findings.py
+++ b/tests/test_scan_findings.py
@@ -1,0 +1,48 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts import scan  # noqa: E402
+
+
+def test_scan_reports_compromised_dependency(tmp_path):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    (project_dir / "package.json").write_text(
+        json.dumps({"dependencies": {"left-pad": "1.0.0"}}),
+        encoding="utf-8",
+    )
+
+    advisory = tmp_path / "advisory.json"
+    advisory.write_text(
+        json.dumps({"items": [{"package": "left-pad", "version": "1.0.0"}]}),
+        encoding="utf-8",
+    )
+
+    log_dir = tmp_path / "logs"
+
+    exit_code = scan.run(
+        [
+            str(project_dir),
+            "--advisory-file",
+            str(advisory),
+            "--log-dir",
+            str(log_dir),
+            "--log-level",
+            "INFO",
+        ]
+    )
+
+    assert exit_code == 1
+
+    log_files = sorted(log_dir.glob("shai_hulud_scan_*.log"))
+    assert log_files, "expected scan log to be written"
+    log_text = log_files[-1].read_text(encoding="utf-8")
+
+    assert "Detected compromised dependencies" in log_text
+    assert "- left-pad@1.0.0" in log_text
+    assert "Total findings: 1" in log_text


### PR DESCRIPTION
## Summary
- limit setuptools package discovery to scripts and config modules
- ship advisory configuration package and ignore build artifacts
- add regression test demonstrating compromised finding output

## Testing
- pytest